### PR TITLE
Add restaurant selection step after login

### DIFF
--- a/src/app/(admin)/login/adminLoginForm.tsx
+++ b/src/app/(admin)/login/adminLoginForm.tsx
@@ -33,10 +33,25 @@ export default function LoginForm() {
 
   const onSubmit = async (data: LoginFormInputs) => {
     try {
-      await loginAdmin(data); 
+      await loginAdmin(data);
 
       const session = localStorage.getItem("adminSession");
       const parsed = session ? JSON.parse(session) : null;
+
+      if (parsed?.payload && !parsed.payload.restaurant && Array.isArray(parsed.payload.restaurants)) {
+        if (parsed.payload.restaurants.length === 1) {
+          const restaurant = parsed.payload.restaurants[0];
+          parsed.payload.restaurant = restaurant;
+          parsed.payload.slug = restaurant.slug;
+          localStorage.setItem("adminSession", JSON.stringify(parsed));
+        } else {
+          toast.success("Login successful! Redirecting...");
+          reset();
+          setTimeout(() => router.replace("/select-restaurant"), 2000);
+          return;
+        }
+      }
+
       const isActive = parsed?.payload?.restaurant?.is_active;
 
       if (isActive === false) {

--- a/src/app/(admin)/select-restaurant/page.tsx
+++ b/src/app/(admin)/select-restaurant/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Navbar from "@/components/subscribers/navbar/Navbar";
+import ButtonPrimary from "@/components/buttons/ButtonPrimary";
+
+interface Restaurant {
+  id: string;
+  name: string;
+  slug: string;
+  is_active?: boolean;
+  [key: string]: any;
+}
+
+export default function SelectRestaurantPage() {
+  const router = useRouter();
+  const [restaurants, setRestaurants] = useState<Restaurant[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("adminSession");
+    if (!stored) {
+      router.replace("/login");
+      return;
+    }
+    try {
+      const parsed = JSON.parse(stored);
+      if (parsed.payload?.restaurant) {
+        router.replace("/dashboard");
+        return;
+      }
+      const list = parsed.payload?.restaurants;
+      if (Array.isArray(list)) {
+        if (list.length === 1) {
+          const r = list[0];
+          parsed.payload.restaurant = r;
+          parsed.payload.slug = r.slug;
+          localStorage.setItem("adminSession", JSON.stringify(parsed));
+          router.replace("/dashboard");
+          return;
+        }
+        setRestaurants(list);
+      } else {
+        router.replace("/dashboard");
+      }
+    } catch {
+      router.replace("/login");
+    }
+  }, [router]);
+
+  const handleSelect = (restaurant: Restaurant) => {
+    const stored = localStorage.getItem("adminSession");
+    if (!stored) {
+      router.replace("/login");
+      return;
+    }
+    try {
+      const parsed = JSON.parse(stored);
+      parsed.payload.restaurant = restaurant;
+      parsed.payload.slug = restaurant.slug;
+      localStorage.setItem("adminSession", JSON.stringify(parsed));
+      router.replace("/dashboard");
+    } catch {
+      router.replace("/login");
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col bg-[#e6ebf2]">
+      <Navbar />
+      <div className="flex flex-col flex-1 items-center justify-center p-4 gap-4">
+        <h2 className="text-2xl md:text-3xl font-bold text-center text-[#4f89f5]">
+          Select your restaurant
+        </h2>
+        <div className="w-full max-w-md space-y-4">
+          {restaurants.map((r) => (
+            <ButtonPrimary key={r.id} onClick={() => handleSelect(r)}>
+              {r.name}
+            </ButtonPrimary>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add intermediate page to pick a restaurant when admin login token includes multiple restaurants
- update login flow to redirect to new page and set selected restaurant in local storage

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495dce51b0832fb8d03de392bed052