### PR TITLE
Fix auth context sync on restaurant selection

### DIFF
--- a/src/app/(admin)/login/adminLoginForm.tsx
+++ b/src/app/(admin)/login/adminLoginForm.tsx
@@ -8,14 +8,14 @@ import { loginSchema } from "../signup/authSchema";
 import { useRouter } from "next/navigation";
 import { toast } from "react-hot-toast";
 import Link from "next/link";
-import { useAuth } from "./adminLoginContext";
+import { useAuth } from "@/app/(admin)/login/adminLoginContext";
 import PasswordInput from "@/components/adminComponents/sessionInputs/PaswordInput";
 import { useState } from "react";
 
 type LoginFormInputs = z.infer<typeof loginSchema>;
 
 export default function LoginForm() {
-  const { loginAdmin } = useAuth();
+  const { loginAdmin, setUser } = useAuth();
   const router = useRouter();
 
   const [isRestaurantInactive, setIsRestaurantInactive] = useState(false);
@@ -44,6 +44,7 @@ export default function LoginForm() {
           parsed.payload.restaurant = restaurant;
           parsed.payload.slug = restaurant.slug;
           localStorage.setItem("adminSession", JSON.stringify(parsed));
+          setUser(parsed);
         } else {
           toast.success("Login successful! Redirecting...");
           reset();

--- a/src/app/(admin)/select-restaurant/page.tsx
+++ b/src/app/(admin)/select-restaurant/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Navbar from "@/components/subscribers/navbar/Navbar";
 import ButtonPrimary from "@/components/buttons/ButtonPrimary";
+import { useAuth } from "@/app/(admin)/login/adminLoginContext";
 
 interface Restaurant {
   id: string;
@@ -15,6 +16,7 @@ interface Restaurant {
 
 export default function SelectRestaurantPage() {
   const router = useRouter();
+  const { setUser } = useAuth();
   const [restaurants, setRestaurants] = useState<Restaurant[]>([]);
 
   useEffect(() => {
@@ -36,6 +38,7 @@ export default function SelectRestaurantPage() {
           parsed.payload.restaurant = r;
           parsed.payload.slug = r.slug;
           localStorage.setItem("adminSession", JSON.stringify(parsed));
+          setUser(parsed);
           router.replace("/dashboard");
           return;
         }
@@ -59,6 +62,7 @@ export default function SelectRestaurantPage() {
       parsed.payload.restaurant = restaurant;
       parsed.payload.slug = restaurant.slug;
       localStorage.setItem("adminSession", JSON.stringify(parsed));
+      setUser(parsed);
       router.replace("/dashboard");
     } catch {
       router.replace("/login");


### PR DESCRIPTION
## Summary
- update select-restaurant page to keep auth context in sync
- keep user context updated when logging in and auto-selecting a restaurant
- switch to absolute import for `useAuth`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684968ce66d0832f8494a5da5b865932