### PR TITLE
Handle multiple restaurants after login

### DIFF
--- a/src/app/(admin)/login/adminLoginForm.tsx
+++ b/src/app/(admin)/login/adminLoginForm.tsx
@@ -38,13 +38,20 @@ export default function LoginForm() {
       const session = localStorage.getItem("adminSession");
       const parsed = session ? JSON.parse(session) : null;
 
-      if (parsed?.payload && !parsed.payload.restaurant && Array.isArray(parsed.payload.restaurants)) {
+      if (
+        parsed?.payload &&
+        !parsed.payload.restaurant &&
+        Array.isArray(parsed.payload.restaurants)
+      ) {
         if (parsed.payload.restaurants.length === 1) {
           const restaurant = parsed.payload.restaurants[0];
           parsed.payload.restaurant = restaurant;
           parsed.payload.slug = restaurant.slug;
           localStorage.setItem("adminSession", JSON.stringify(parsed));
-        } else {
+        } else if (parsed.payload.restaurants.length > 1) {
+          delete parsed.payload.slug;
+          delete parsed.payload.restaurant;
+          localStorage.setItem("adminSession", JSON.stringify(parsed));
           toast.success("Login successful! Redirecting...");
           reset();
           setTimeout(() => router.replace("/select-restaurant"), 2000);


### PR DESCRIPTION
## Summary
- detect multiple restaurants on login
- remove slug and unset restaurant when more than one is present
- store cleaned session and redirect to select-restaurant

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68496b30c8f0832fb4e47d11d2db2d7d