### PR TITLE
Rename admin login page component

### DIFF
--- a/src/app/(admin)/login/page.tsx
+++ b/src/app/(admin)/login/page.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import LoginForm from './adminLoginForm'
 import Navbar from '@/components/subscribers/navbar/Navbar';
 
-const AdminRegisterPage = () => {
+const AdminLoginPage = () => {
   const cloudName = process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
 
   return (
@@ -31,4 +31,4 @@ const AdminRegisterPage = () => {
   )
 }
 
-export default AdminRegisterPage
+export default AdminLoginPage


### PR DESCRIPTION
## Summary
- rename `AdminRegisterPage` to `AdminLoginPage` in admin login page
- update default export

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684973bf53b4832fa56c3a238949c654