### PR TITLE
Centralize JWT parsing

### DIFF
--- a/src/app/(admin)/login/adminLoginContext.tsx
+++ b/src/app/(admin)/login/adminLoginContext.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useEffect, useState, ReactNode } from "react
 import Cookies from "js-cookie";
 import { useRouter } from "next/navigation";
 import { IAdminLogin } from "@/types";
+import { parseJwt } from "@/utils/jwt";
 
 const APIURL = process.env.NEXT_PUBLIC_API_URL;
 
@@ -21,16 +22,6 @@ interface IAuthContextProps {
 
 const AuthContext = createContext<IAuthContextProps | undefined>(undefined);
 
-function parseJwt(token: string) {
-    try {
-        const base64Payload = token.split(".")[1];
-        const payload = atob(base64Payload);
-        return JSON.parse(payload);
-    } catch (e) {
-        console.error("Error parsing JWT:", e);
-        return null;
-    }
-}
 
 export const AdminLoginProvider = ({ children }: { children: ReactNode }) => {
     const [user, setUser] = useState<IAdminSessionStorage | null>(null);

--- a/src/app/dashboard/promocodes/page.tsx
+++ b/src/app/dashboard/promocodes/page.tsx
@@ -7,17 +7,8 @@ import NavbarAdmin from "@/components/adminComponents/navbar/NavbarAdmin";
 import PromoCodesContainer from "@/components/adminComponents/promoCodes/PromoCodesContainer";
 import Footer from "@/components/subscribers/footer/Footer";
 import Cookies from "js-cookie";
+import { parseJwt } from "@/utils/jwt";
 
-function parseJwt(token: string) {
-    try {
-        const base64Payload = token.split(".")[1];
-        const payload = atob(base64Payload);
-        return JSON.parse(payload);
-    } catch (e) {
-        console.error("Invalid token");
-        return null;
-    }
-}
 
 const PromoCodesPage = () => {
     const router = useRouter();

--- a/src/components/adminComponents/editableRestaurant/landingPage/StorePageAdmin.tsx
+++ b/src/components/adminComponents/editableRestaurant/landingPage/StorePageAdmin.tsx
@@ -9,16 +9,8 @@ import StoreInfoModal from "./StoreInfoAdmin";
 import Cookies from "js-cookie";
 import { toast } from "react-hot-toast";
 import { PencilIcon } from "lucide-react";
+import { parseJwt } from "@/utils/jwt";
 
-function parseJwt(token: string) {
-    try {
-        const base64Payload = token.split(".")[1];
-        const payload = atob(base64Payload);
-        return JSON.parse(payload);
-    } catch {
-        return null;
-    }
-}
 
 export default function StorePageAdmin() {
     const router = useRouter();

--- a/src/components/adminComponents/settings/Settings.tsx
+++ b/src/components/adminComponents/settings/Settings.tsx
@@ -10,16 +10,8 @@ import toast from "react-hot-toast";
 import ButtonPrimary from "@/components/buttons/ButtonPrimary";
 import PasswordInput from "@/components/adminComponents/sessionInputs/PaswordInput";
 import Cookies from "js-cookie";
+import { parseJwt } from "@/utils/jwt";
 
-function parseJwt(token: string) {
-    try {
-        const base64Payload = token.split(".")[1];
-        const payload = atob(base64Payload);
-        return JSON.parse(payload);
-    } catch {
-        return null;
-    }
-}
 
 const Settings = () => {
     const router = useRouter();

--- a/src/components/staffComponents/orders/CompletedOrders.tsx
+++ b/src/components/staffComponents/orders/CompletedOrders.tsx
@@ -11,6 +11,7 @@ import { MdTakeoutDining } from "react-icons/md";
 import { RiTakeawayFill, RiTakeawayLine } from "react-icons/ri";
 import { GiBoxUnpacking } from "react-icons/gi";
 import { CgMenuBoxed } from "react-icons/cg";
+import { parseJwt } from "@/utils/jwt";
 
 const transformOrderFromApi = (order: any): IOrder => ({
     id: order.id,
@@ -30,15 +31,6 @@ const transformOrderFromApi = (order: any): IOrder => ({
     })),
 });
 
-function parseJwt(token: string) {
-    try {
-        const base64Payload = token.split(".")[1];
-        const payload = atob(base64Payload);
-        return JSON.parse(payload);
-    } catch {
-        return null;
-    }
-}
 
 export default function CompletedOrdersPage() {
     const [orders, setOrders] = useState<IOrder[]>([]);

--- a/src/components/staffComponents/orders/OrderCardList.tsx
+++ b/src/components/staffComponents/orders/OrderCardList.tsx
@@ -7,17 +7,8 @@ import toast from "react-hot-toast";
 import { useRouter } from "next/navigation";
 import Cookies from "js-cookie";
 import { Loader2, Clock4, ChefHat, Bell } from "lucide-react";
+import { parseJwt } from "@/utils/jwt";
 
-function parseJwt(token: string) {
-    try {
-        const base64Payload = token.split(".")[1];
-        const payload = atob(base64Payload);
-        return JSON.parse(payload);
-    } catch (e) {
-        console.error("Invalid token");
-        return null;
-    }
-}
 
 export default function OrderCardList() {
     const [orders, setOrders] = useState<IOrder[]>([]);

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,0 +1,8 @@
+export function parseJwt(token: string) {
+  try {
+    const base64Payload = token.split(".")[1];
+    return JSON.parse(atob(base64Payload));
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add shared `parseJwt` helper
- use `parseJwt` util in admin login, promo codes, orders, settings, store page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684973c195f4832f8d47862efae597af