### PR TITLE
Update admin session types

### DIFF
--- a/src/app/(admin)/login/adminLoginContext.tsx
+++ b/src/app/(admin)/login/adminLoginContext.tsx
@@ -3,14 +3,10 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from "react";
 import Cookies from "js-cookie";
 import { useRouter } from "next/navigation";
-import { IAdminLogin } from "@/types";
+import { IAdminLogin, IAdminSessionStorage } from "@/types";
 
 const APIURL = process.env.NEXT_PUBLIC_API_URL;
 
-type IAdminSessionStorage = {
-    token: string;
-    payload: any;
-};
 
 interface IAuthContextProps {
     user: IAdminSessionStorage | null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,18 @@ export interface IAdminRegister {
     confirmPassword: string;
 }
 
+export interface IAdminSessionPayload {
+    sub: string;
+    id: string;
+    email: string;
+    roles: string[];
+    name: string;
+    phone: string;
+    restaurants?: IRestaurant[];
+    restaurant?: IRestaurant;
+    slug?: string;
+}
+
 export interface IAdminSession {
     token: string;
     payload: {
@@ -35,10 +47,10 @@ export interface IAdminSession {
     };
 }
 
-export type IAdminSessionStorage = {
+export interface IAdminSessionStorage {
     token: string;
-    payload: any;
-};
+    payload: IAdminSessionPayload;
+}
 
 export interface ICategory {
     id: number;


### PR DESCRIPTION
## Summary
- define `IAdminSessionPayload` interface for admin JWT payload
- change `IAdminSessionStorage` to include typed `payload`
- use the new exported type in `adminLoginContext`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684973c319c8832fb387a04ca72f18dd