### PR TITLE
Add restaurant selection modal after login

### DIFF
--- a/src/app/(admin)/login/adminLoginForm.tsx
+++ b/src/app/(admin)/login/adminLoginForm.tsx
@@ -11,6 +11,8 @@ import Link from "next/link";
 import { useAuth } from "@/app/(admin)/login/adminLoginContext";
 import PasswordInput from "@/components/adminComponents/sessionInputs/PaswordInput";
 import { useState } from "react";
+import RestaurantSelectModal from "@/components/adminComponents/modals/RestaurantSelectModal";
+import { Restaurant } from "@/types";
 
 type LoginFormInputs = z.infer<typeof loginSchema>;
 
@@ -19,6 +21,8 @@ export default function LoginForm() {
   const router = useRouter();
 
   const [isRestaurantInactive, setIsRestaurantInactive] = useState(false);
+  const [showRestaurantModal, setShowRestaurantModal] = useState(false);
+  const [restaurants, setRestaurants] = useState<Restaurant[]>([]);
 
   const {
     register,
@@ -46,9 +50,10 @@ export default function LoginForm() {
           localStorage.setItem("adminSession", JSON.stringify(parsed));
           setUser(parsed);
         } else {
-          toast.success("Login successful! Redirecting...");
+          setRestaurants(parsed.payload.restaurants);
+          setShowRestaurantModal(true);
+          toast.success("Login successful! Select your restaurant");
           reset();
-          setTimeout(() => router.replace("/select-restaurant"), 2000);
           return;
         }
       }
@@ -76,6 +81,28 @@ export default function LoginForm() {
       setError("password", { message });
     }
   };
+
+  const handleRestaurantSelect = (restaurant: Restaurant) => {
+    const session = localStorage.getItem("adminSession");
+    if (!session) {
+      router.replace("/login");
+      return;
+    }
+    try {
+      const parsed = JSON.parse(session);
+      parsed.payload.restaurant = restaurant;
+      parsed.payload.slug = restaurant.slug;
+      localStorage.setItem("adminSession", JSON.stringify(parsed));
+      setUser(parsed);
+      toast.success("Restaurant selected! Redirecting...");
+      setShowRestaurantModal(false);
+      router.replace("/dashboard");
+    } catch {
+      router.replace("/login");
+    }
+  };
+
+  const closeRestaurantModal = () => setShowRestaurantModal(false);
 
   return (
     <div className="relative max-w-md mx-auto mt-10 p-6 bg-neutral-100 rounded-xl">
@@ -114,6 +141,12 @@ export default function LoginForm() {
           </Link>
         </p>
       </form>
+      <RestaurantSelectModal
+        open={showRestaurantModal}
+        restaurants={restaurants}
+        onSelect={handleRestaurantSelect}
+        onClose={closeRestaurantModal}
+      />
     </div>
   );
 }

--- a/src/app/(admin)/login/page.tsx
+++ b/src/app/(admin)/login/page.tsx
@@ -31,4 +31,4 @@ const AdminRegisterPage = () => {
   )
 }
 
-export default AdminRegisterPage
+export default AdminRegisterPage;

--- a/src/components/adminComponents/modals/RestaurantSelectModal.tsx
+++ b/src/components/adminComponents/modals/RestaurantSelectModal.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Restaurant } from "@/types";
+
+interface RestaurantSelectModalProps {
+  open: boolean;
+  restaurants: Restaurant[];
+  onSelect: (restaurant: Restaurant) => void;
+  onClose: () => void;
+}
+
+export default function RestaurantSelectModal({
+  open,
+  restaurants,
+  onSelect,
+  onClose,
+}: RestaurantSelectModalProps) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-white rounded-xl p-6 shadow-lg w-full max-w-sm">
+        <h2 className="text-xl font-semibold mb-4 text-center">Select Restaurant</h2>
+        <div className="space-y-2">
+          {restaurants.map((r) => (
+            <button
+              key={r.id}
+              onClick={() => onSelect(r)}
+              className="w-full px-4 py-2 bg-branding-600 text-white rounded hover:bg-branding-500"
+            >
+              {r.name}
+            </button>
+          ))}
+        </div>
+        <div className="flex justify-end mt-4">
+          <button onClick={onClose} className="text-sm text-gray-500 hover:underline">
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show a modal with available restaurants after login
- store chosen restaurant and redirect to dashboard

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497b9c8f14832fbc1f43c9446a3ae1