### PR TITLE
Adjust modal overlay styling

### DIFF
--- a/src/components/adminComponents/billing/Billing.tsx
+++ b/src/components/adminComponents/billing/Billing.tsx
@@ -150,8 +150,9 @@ export default function BillingComponent() {
             </div>
 
             {showConfirm && (
-                <div className="fixed inset-0 bg-black/30 bg-opacity-30 z-50 flex items-center justify-center">
-                    <div className="bg-white rounded-2xl shadow-xl p-6 max-w-sm w-full space-y-4">
+                <div className="fixed inset-0 z-50 flex items-center justify-center relative">
+                    <div className="absolute inset-0 bg-black/20 backdrop-blur-sm pointer-events-none z-40" />
+                    <div className="bg-white rounded-2xl shadow-xl p-6 max-w-sm w-full space-y-4 relative z-50 pointer-events-auto">
                         <h2 className="text-xl font-semibold text-gray-800">Cancel Subscription</h2>
                         <p className="text-sm text-gray-600">Are you sure you want to cancel your subscription? This change will take effect at the end of your current billing period.</p>
                         <div className="flex justify-end gap-4 pt-4">

--- a/src/components/adminComponents/modals/RestaurantSelectModal.tsx
+++ b/src/components/adminComponents/modals/RestaurantSelectModal.tsx
@@ -18,8 +18,9 @@ export default function RestaurantSelectModal({
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-      <div className="bg-white rounded-xl p-6 shadow-lg w-full max-w-sm">
+    <div className="fixed inset-0 z-50 flex items-center justify-center relative">
+      <div className="absolute inset-0 bg-black/20 backdrop-blur-sm pointer-events-none z-40" />
+      <div className="bg-white rounded-xl p-6 shadow-lg w-full max-w-sm relative z-50 pointer-events-auto">
         <h2 className="text-xl font-semibold mb-4 text-center">Select Restaurant</h2>
         <div className="space-y-2">
           {restaurants.map((r) => (

--- a/src/components/adminComponents/tables/tables/buttonsTable/DeleteTableButton.tsx
+++ b/src/components/adminComponents/tables/tables/buttonsTable/DeleteTableButton.tsx
@@ -60,8 +60,9 @@ const DeleteTableButton: React.FC<Props> = ({ tableId, onTableDeleted }) => {
             </button>
 
             {showConfirm && (
-                <div className="fixed inset-0 bg-opacity-50 flex justify-center items-center z-50">
-                    <div className="bg-white p-6 rounded-lg shadow-lg max-w-sm w-full text-center">
+                <div className="fixed inset-0 z-50 flex justify-center items-center relative">
+                    <div className="absolute inset-0 bg-black/20 backdrop-blur-sm pointer-events-none z-40" />
+                    <div className="bg-white p-6 rounded-lg shadow-lg max-w-sm w-full text-center relative z-50 pointer-events-auto">
                         <h3 className="text-lg font-semibold mb-4">Are you sure?</h3>
                         <p className="text-sm text-gray-600 mb-6">This action will permanently delete the table.</p>
                         <div className="flex justify-center gap-4">

--- a/src/components/adminComponents/tables/tables/buttonsTable/EditTableButton.tsx
+++ b/src/components/adminComponents/tables/tables/buttonsTable/EditTableButton.tsx
@@ -67,8 +67,9 @@ const EditTableButton: React.FC<Props> = ({ tableId, currentCode, isActive, onTa
             </button>
 
             {showModal && (
-                <div className="fixed inset-0 bg-opacity-50 flex justify-center items-center z-50">
-                    <div className="bg-white p-6 rounded-lg shadow-lg max-w-sm w-full text-center">
+                <div className="fixed inset-0 z-50 flex justify-center items-center relative">
+                    <div className="absolute inset-0 bg-black/20 backdrop-blur-sm pointer-events-none z-40" />
+                    <div className="bg-white p-6 rounded-lg shadow-lg max-w-sm w-full text-center relative z-50 pointer-events-auto">
                         <h3 className="text-lg font-semibold mb-4">Edit table name</h3>
                         <input
                             type="text"

--- a/src/components/shared/categoryList.tsx
+++ b/src/components/shared/categoryList.tsx
@@ -69,7 +69,8 @@ export default function PublicCategoryList({ categories, slug }: Props) {
           </div>
 
           {selectedProduct && (
-            <div className="fixed inset-0 bg-black/10 z-50 flex items-center justify-center px-4">
+            <div className="fixed inset-0 z-50 flex items-center justify-center px-4 relative">
+              <div className="absolute inset-0 bg-black/20 backdrop-blur-sm pointer-events-none z-40" />
               <ProductDetail
                 {...selectedProduct}
                 slug={slug}

--- a/src/components/superAdminComponents/restaurantes/EditRestaurantModal.tsx
+++ b/src/components/superAdminComponents/restaurantes/EditRestaurantModal.tsx
@@ -57,9 +57,9 @@ export default function EditRestaurantModal({ restaurant, onClose, onUpdated }: 
 
     return (
         <Dialog open={isOpen} onClose={handleClose} className="relative z-50">
-            <div className="fixed inset-0 bg-black/40" aria-hidden="true" />
-            <div className="fixed inset-0 flex items-center justify-center p-4">
-                <DialogPanel className="w-full max-w-md bg-white rounded-xl p-6 space-y-4 shadow-xl">
+            <div className="fixed inset-0 bg-black/20 backdrop-blur-sm pointer-events-none z-40" aria-hidden="true" />
+            <div className="fixed inset-0 flex items-center justify-center p-4 relative z-50">
+                <DialogPanel className="w-full max-w-md bg-white rounded-xl p-6 space-y-4 shadow-xl relative z-50">
                     <DialogTitle className="text-lg font-bold">Edit Restaurant</DialogTitle>
 
                     <div className="space-y-2">

--- a/src/components/superAdminComponents/ui/Dialog.tsx
+++ b/src/components/superAdminComponents/ui/Dialog.tsx
@@ -12,8 +12,11 @@ export const Dialog: React.FC<DialogProps> = ({ open, onOpenChange, children }) 
     if (!open) return null;
 
     return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-            <div className="bg-white rounded-lg shadow-lg w-full max-w-md p-4 relative">{children}</div>
+        <div className="fixed inset-0 z-50 flex items-center justify-center relative">
+            <div className="absolute inset-0 bg-black/20 backdrop-blur-sm pointer-events-none z-40" />
+            <div className="bg-white rounded-lg shadow-lg w-full max-w-md p-4 relative z-50 pointer-events-auto">
+                {children}
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- use consistent blur overlay for dialogs and modals
- ensure modals sit above overlay with z-index tweaks

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497e1ead80832f8a05ce8ac4846806