### PR TITLE
Fix missing orders due to slug retrieval

### DIFF
--- a/src/components/staffComponents/orders/CompletedOrders.tsx
+++ b/src/components/staffComponents/orders/CompletedOrders.tsx
@@ -67,13 +67,30 @@ export default function CompletedOrdersPage() {
         const payload = parseJwt(cookieToken);
         const roles = payload?.roles;
 
+        let slugFromStorage = "";
+        if (typeof window !== "undefined") {
+            const sessionRaw = localStorage.getItem("adminSession");
+            if (sessionRaw) {
+                try {
+                    const session = JSON.parse(sessionRaw);
+                    slugFromStorage =
+                        session.restaurant?.slug ||
+                        session.payload?.restaurant?.slug ||
+                        session.payload?.slug ||
+                        "";
+                } catch {
+                    slugFromStorage = "";
+                }
+            }
+        }
+
         if (!roles || (!roles.includes("owner") && !roles.includes("staff"))) {
             router.push("/404");
             return;
         }
 
         setToken(cookieToken);
-        setSlug(payload.slug);
+        setSlug(payload.slug || slugFromStorage);
         setAuthorized(true);
         setCheckingAuth(false);
     }, [router]);

--- a/src/components/staffComponents/orders/OrderCardList.tsx
+++ b/src/components/staffComponents/orders/OrderCardList.tsx
@@ -45,9 +45,26 @@ export default function OrderCardList() {
         const payload = parseJwt(cookieToken);
         const role = payload?.roles;
 
+        let slugFromStorage = "";
+        if (typeof window !== "undefined") {
+            const sessionRaw = localStorage.getItem("adminSession");
+            if (sessionRaw) {
+                try {
+                    const session = JSON.parse(sessionRaw);
+                    slugFromStorage =
+                        session.restaurant?.slug ||
+                        session.payload?.restaurant?.slug ||
+                        session.payload?.slug ||
+                        "";
+                } catch {
+                    slugFromStorage = "";
+                }
+            }
+        }
+
         if (role === "owner" || role === "staff") {
             setToken(cookieToken);
-            setSlug(payload?.slug || "");
+            setSlug(payload?.slug || slugFromStorage);
             setAuthorized(true);
         } else {
             router.push("/404");


### PR DESCRIPTION
## Summary
- fall back to slug stored in localStorage when loading orders

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a2bba540832fb35407769ce33cfe