### PR TITLE
Poll orders on staff pages

### DIFF
--- a/src/components/staffComponents/orders/CompletedOrders.tsx
+++ b/src/components/staffComponents/orders/CompletedOrders.tsx
@@ -128,6 +128,12 @@ export default function CompletedOrdersPage() {
         };
 
         fetchData();
+
+        const intervalId = setInterval(() => {
+            fetchData();
+        }, 10000);
+
+        return () => clearInterval(intervalId);
     }, [slug, token, authorized]);
 
     const updateOrderStatus = async (orderId: string, newStatus: string) => {

--- a/src/components/staffComponents/orders/OrderCardList.tsx
+++ b/src/components/staffComponents/orders/OrderCardList.tsx
@@ -113,6 +113,12 @@ export default function OrderCardList() {
         };
 
         fetchData();
+
+        const intervalId = setInterval(() => {
+            fetchData();
+        }, 10000);
+
+        return () => clearInterval(intervalId);
     }, [slug, token, authorized]);
 
         const updateOrderStatus = async (orderId: string, newStatus: string) => {


### PR DESCRIPTION
## Summary
- refresh current orders for staff every 10s
- refresh completed orders every 10s as well

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849a86adb10832fb073724b59af3bb0