### PR TITLE
Fix promo code slug handling

### DIFF
--- a/src/components/adminComponents/promoCodes/ListPromoCode.tsx
+++ b/src/components/adminComponents/promoCodes/ListPromoCode.tsx
@@ -29,14 +29,24 @@ const PromoCodesList = ({ refreshTrigger }: { refreshTrigger: number }) => {
       const session = localStorage.getItem("adminSession");
       if (!session) return { slug: "", token: "" };
       const parsed = JSON.parse(session);
-      return { slug: parsed.payload?.slug || "", token: parsed.token || "" };
+      const slug =
+        parsed.restaurant?.slug ||
+        parsed.payload?.restaurant?.slug ||
+        parsed.payload?.slug ||
+        parsed.restaurants?.[0]?.slug ||
+        parsed.payload?.restaurants?.[0]?.slug ||
+        "";
+      return { slug, token: parsed.token || "" };
     } catch {
       return { slug: "", token: "" };
     }
   })();
 
   const fetchPromoCodes = async () => {
-    if (!slug || !token) return;
+    if (!slug || !token) {
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     try {
       const response = await getPromoCodes(slug, token);

--- a/src/components/adminComponents/promoCodes/PromoCodesForm.tsx
+++ b/src/components/adminComponents/promoCodes/PromoCodesForm.tsx
@@ -19,7 +19,14 @@ const PromoCodeForm = ({ onCodeCreated }: { onCodeCreated?: () => void }) => {
       const session = localStorage.getItem("adminSession");
       if (!session) return;
       const parsed = JSON.parse(session);
-      setSlug(parsed.payload?.slug || "");
+      const extractedSlug =
+        parsed.restaurant?.slug ||
+        parsed.payload?.restaurant?.slug ||
+        parsed.payload?.slug ||
+        parsed.restaurants?.[0]?.slug ||
+        parsed.payload?.restaurants?.[0]?.slug ||
+        "";
+      setSlug(extractedSlug);
       setToken(parsed.token || "");
     } catch {
       setSlug("");


### PR DESCRIPTION
## Summary
- support multiple admin session structures when fetching slug for promo codes
- stop showing spinner when slug can't be retrieved

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ac17d858832fa8595a51ff04d6e0