### PR TITLE
Fix promo code list not loading

### DIFF
--- a/src/app/dashboard/promocodes/page.tsx
+++ b/src/app/dashboard/promocodes/page.tsx
@@ -37,8 +37,22 @@ const PromoCodesPage = () => {
         if (payload?.roles === "owner") {
             setAuthorized(true);
 
-           
-            localStorage.setItem("adminSession", JSON.stringify({ token, payload }));
+            // Preserve existing restaurant/slug data stored in localStorage
+            try {
+                const existing = localStorage.getItem("adminSession");
+                if (existing) {
+                    const parsed = JSON.parse(existing);
+                    const mergedPayload = { ...payload, ...parsed.payload };
+                    localStorage.setItem(
+                        "adminSession",
+                        JSON.stringify({ token, payload: mergedPayload })
+                    );
+                } else {
+                    localStorage.setItem("adminSession", JSON.stringify({ token, payload }));
+                }
+            } catch {
+                localStorage.setItem("adminSession", JSON.stringify({ token, payload }));
+            }
         } else {
             router.push("/404");
         }


### PR DESCRIPTION
## Summary
- preserve existing restaurant data when setting admin session on promo codes page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ad7831e0832fa6339ab089b71833