### PR TITLE
Fix settings access when slug is missing from token

### DIFF
--- a/src/components/adminComponents/settings/Settings.tsx
+++ b/src/components/adminComponents/settings/Settings.tsx
@@ -43,8 +43,27 @@ const Settings = () => {
 
         const payload = parseJwt(cookieToken);
         const role = payload?.roles;
-        const slug = payload?.slug;
+        let slug = payload?.slug;
         const userId = payload?.sub;
+
+        let slugFromStorage = "";
+        if (typeof window !== "undefined") {
+            const sessionRaw = localStorage.getItem("adminSession");
+            if (sessionRaw) {
+                try {
+                    const session = JSON.parse(sessionRaw);
+                    slugFromStorage =
+                        session.restaurant?.slug ||
+                        session.payload?.restaurant?.slug ||
+                        session.payload?.slug ||
+                        "";
+                } catch {
+                    slugFromStorage = "";
+                }
+            }
+        }
+
+        slug = slug || slugFromStorage;
 
         if (!role || (!role.includes("owner") && !role.includes("staff")) || !slug || !userId) {
             router.push("/404");


### PR DESCRIPTION
## Summary
- look for slug in `localStorage` if it isn't present in the JWT cookie

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b0132d2c832f957aed3f87d79d34