### PR TITLE
Reset useForm on email mode switch

### DIFF
--- a/src/app/(admin)/signup/AdminRegisterForm.tsx
+++ b/src/app/(admin)/signup/AdminRegisterForm.tsx
@@ -12,7 +12,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "react-hot-toast";
 import Link from "next/link";
 import ButtonPrimary from "@/components/buttons/ButtonPrimary";
-import { useState } from "react";
+import { useState, useMemo, useEffect } from "react";
 import PasswordInput from "@/components/adminComponents/sessionInputs/PaswordInput";
 
 export default function RegisterForm() {
@@ -21,15 +21,24 @@ export default function RegisterForm() {
     const router = useRouter();
     const APIURL = process.env.NEXT_PUBLIC_API_URL;
 
+    const formResolver = useMemo(
+        () => zodResolver(emailExists ? AdminRestaurantSchema : AdminRegisterSchema),
+        [emailExists]
+    );
+
     const {
         register,
         handleSubmit,
         formState: { errors, isSubmitting },
         reset,
     } = useForm<RegisterFormInputs>({
-        resolver: zodResolver(emailExists ? AdminRestaurantSchema : AdminRegisterSchema),
+        resolver: formResolver,
         mode: "onChange",
     });
+
+    useEffect(() => {
+        reset();
+    }, [emailExists, reset]);
 
     const handleEmailBlur = async (e: React.FocusEvent<HTMLInputElement>) => {
         const email = e.target.value;


### PR DESCRIPTION
## Summary
- memoize the zod resolver in `AdminRegisterForm`
- reset form when switching sign-up modes

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c0b78e14832f998a713ea831993b