### PR TITLE
Fix admin register flow reset

### DIFF
--- a/src/app/(admin)/signup/AdminRegisterForm.tsx
+++ b/src/app/(admin)/signup/AdminRegisterForm.tsx
@@ -12,7 +12,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "react-hot-toast";
 import Link from "next/link";
 import ButtonPrimary from "@/components/buttons/ButtonPrimary";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import PasswordInput from "@/components/adminComponents/sessionInputs/PaswordInput";
 
 export default function RegisterForm() {
@@ -26,6 +26,7 @@ export default function RegisterForm() {
         handleSubmit,
         formState: { errors, isSubmitting },
         reset,
+        getValues,
     } = useForm<RegisterFormInputs>({
         resolver: zodResolver(emailExists ? AdminRestaurantSchema : AdminRegisterSchema),
         mode: "onChange",
@@ -45,6 +46,16 @@ export default function RegisterForm() {
             toast.error("Unable to verify email");
         }
     };
+
+    useEffect(() => {
+        const values = getValues();
+        reset({
+            ...values,
+            ownerName: "",
+            password: "",
+            confirmPassword: "",
+        });
+    }, [emailExists, reset, getValues]);
 
     const onSubmit = async (data: RegisterFormInputs) => {
         setIsLoading(true);


### PR DESCRIPTION
## Summary
- fix admin signup form to reset fields when switching between flows

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c0bd4f20832f99a673e07039ff6b