### PR TITLE
Implement two-step admin signup

### DIFF
--- a/src/app/(admin)/signup/AdminRegisterForm.tsx
+++ b/src/app/(admin)/signup/AdminRegisterForm.tsx
@@ -8,19 +8,18 @@ import {
     AdminRestaurantSchema,
 } from "./authSchema";
 import { checkEmail } from "@/libs/checkEmail";
-import { useRouter } from "next/navigation";
 import { toast } from "react-hot-toast";
 import Link from "next/link";
 import ButtonPrimary from "@/components/buttons/ButtonPrimary";
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo } from "react";
 
 import PasswordInput from "@/components/adminComponents/sessionInputs/PaswordInput";
 
 export default function RegisterForm() {
     const [isLoading, setIsLoading] = useState(false);
     const [emailExists, setEmailExists] = useState(false);
-    const router = useRouter();
+    const [step, setStep] = useState<"email" | "details">("email");
     const APIURL = process.env.NEXT_PUBLIC_API_URL;
 
     const formResolver = useMemo(
@@ -32,41 +31,32 @@ export default function RegisterForm() {
         register,
         handleSubmit,
         formState: { errors, isSubmitting },
-        reset,
         getValues,
+        trigger,
     } = useForm<RegisterFormInputs>({
         resolver: formResolver,
         mode: "onChange",
     });
 
-    useEffect(() => {
-        reset();
-    }, [emailExists, reset]);
-
-    const handleEmailBlur = async (e: React.FocusEvent<HTMLInputElement>) => {
-        const email = e.target.value;
-        if (!email) return;
+    const handleNext = async () => {
+        const valid = await trigger("email");
+        if (!valid) return;
+        setIsLoading(true);
         try {
-            const { exists } = await checkEmail(email);
+            const { exists } = await checkEmail(getValues("email"));
             setEmailExists(exists);
             if (exists) {
                 toast.success("Existing account found. We'll link this restaurant to it.");
             }
+            setStep("details");
         } catch (err) {
             console.error("Email check error", err);
             toast.error("Unable to verify email");
+        } finally {
+            setIsLoading(false);
         }
     };
 
-    useEffect(() => {
-        const values = getValues();
-        reset({
-            ...values,
-            ownerName: "",
-            password: "",
-            confirmPassword: "",
-        });
-    }, [emailExists, reset, getValues]);
 
     const onSubmit = async (data: RegisterFormInputs) => {
         setIsLoading(true);
@@ -116,85 +106,97 @@ export default function RegisterForm() {
     return (
         <div className="max-w-md mx-auto mt-10 mb-10 p-6 bg-default-50 rounded-xl">
             <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 max-w-sm">
-                {!emailExists && (
-                    <div>
-                        <label htmlFor="ownerName">Name and Last Name</label>
-                        <input id="ownerName" {...register("ownerName")} className="w-full p-2 bg-white rounded-md" placeholder="John Smith" />
-                        {errors.ownerName && <p className="text-red-500">{errors.ownerName.message}</p>}
-                    </div>
-                )}
-
-                <div>
-                    <label htmlFor="email">Email</label>
-                    <input
-                        id="email"
-                        {...register("email", { onBlur: handleEmailBlur })}
-                        className="w-full p-2 bg-white rounded-md"
-                        placeholder="johnSmith@mail.com"
-                    />
-                    {errors.email && <p className="text-red-500">{errors.email.message}</p>}
-                    {emailExists && (
-                        <p className="text-green-600 text-sm">Existing account detected. We will assign this restaurant to it.</p>
-                    )}
-                </div>
-
-                <div>
-                    <label htmlFor="storeName">Store Name</label>
-                    <input id="storeName" {...register("storeName")} className="w-full p-2 bg-white rounded-md" placeholder="My Store" />
-                    {errors.storeName && <p className="text-red-500">{errors.storeName.message}</p>}
-                </div>
-
-                <div>
-                    <label htmlFor="slug">Slug</label>
-                    <input id="slug" {...register("slug")} className="w-full p-2 bg-white rounded-md" placeholder="my-store" />
-                    {errors.slug && <p className="text-red-500">{errors.slug.message}</p>}
-                </div>
-
-                {!emailExists && (
+                {step === "email" && (
                     <>
                         <div>
-                            <label htmlFor="password">Password</label>
-                            <PasswordInput register={register} name="password" error={errors.password?.message} />
+                            <label htmlFor="email">Email</label>
+                            <input
+                                id="email"
+                                {...register("email")}
+                                className="w-full p-2 bg-white rounded-md"
+                                placeholder="johnSmith@mail.com"
+                            />
+                            {errors.email && <p className="text-red-500">{errors.email.message}</p>}
                         </div>
-
-                        <div>
-                            <label htmlFor="confirmPassword">Confirm Password</label>
-                            <PasswordInput register={register} name="confirmPassword" error={errors.confirmPassword?.message} />
-                        </div>
+                        <ButtonPrimary type="button" onClick={handleNext} loading={isSubmitting || isLoading}>
+                            Next
+                        </ButtonPrimary>
                     </>
                 )}
 
-                <div>
-                    <label className="block font-medium mb-2">Start with:</label>
-                    <div className="flex items-center space-x-4">
-                        <label className="flex items-center space-x-2">
-                            <input
-                                type="radio"
-                                value="false"
-                                {...register("isTrial", {
-                                    setValueAs: (v) => v === "true",
-                                })}
-                                defaultChecked
-                            />
-                            <span>Pay Now</span>
-                        </label>
-                        <label className="flex items-center space-x-2">
-                            <input
-                                type="radio"
-                                value="true"
-                                {...register("isTrial", {
-                                    setValueAs: (v) => v === "true",
-                                })}
-                            />
-                            <span>Free Trial (14 days)</span>
-                        </label>
-                    </div>
-                    {errors.isTrial && <p className="text-red-500 text-sm">{errors.isTrial.message}</p>}
-                </div>
+                {step === "details" && (
+                    <>
+                        {!emailExists && (
+                            <div>
+                                <label htmlFor="ownerName">Name and Last Name</label>
+                                <input id="ownerName" {...register("ownerName")} className="w-full p-2 bg-white rounded-md" placeholder="John Smith" />
+                                {errors.ownerName && <p className="text-red-500">{errors.ownerName.message}</p>}
+                            </div>
+                        )}
 
-                <ButtonPrimary type="submit" loading={isSubmitting || isLoading}>
-                    Continue to Checkout
-                </ButtonPrimary>
+                        {emailExists && (
+                            <p className="text-green-600 text-sm">Existing account detected. We will assign this restaurant to it.</p>
+                        )}
+
+                        <div>
+                            <label htmlFor="storeName">Store Name</label>
+                            <input id="storeName" {...register("storeName")} className="w-full p-2 bg-white rounded-md" placeholder="My Store" />
+                            {errors.storeName && <p className="text-red-500">{errors.storeName.message}</p>}
+                        </div>
+
+                        <div>
+                            <label htmlFor="slug">Slug</label>
+                            <input id="slug" {...register("slug")} className="w-full p-2 bg-white rounded-md" placeholder="my-store" />
+                            {errors.slug && <p className="text-red-500">{errors.slug.message}</p>}
+                        </div>
+
+                        {!emailExists && (
+                            <>
+                                <div>
+                                    <label htmlFor="password">Password</label>
+                                    <PasswordInput register={register} name="password" error={errors.password?.message} />
+                                </div>
+
+                                <div>
+                                    <label htmlFor="confirmPassword">Confirm Password</label>
+                                    <PasswordInput register={register} name="confirmPassword" error={errors.confirmPassword?.message} />
+                                </div>
+                            </>
+                        )}
+
+                        <div>
+                            <label className="block font-medium mb-2">Start with:</label>
+                            <div className="flex items-center space-x-4">
+                                <label className="flex items-center space-x-2">
+                                    <input
+                                        type="radio"
+                                        value="false"
+                                        {...register("isTrial", {
+                                            setValueAs: (v) => v === "true",
+                                        })}
+                                        defaultChecked
+                                    />
+                                    <span>Pay Now</span>
+                                </label>
+                                <label className="flex items-center space-x-2">
+                                    <input
+                                        type="radio"
+                                        value="true"
+                                        {...register("isTrial", {
+                                            setValueAs: (v) => v === "true",
+                                        })}
+                                    />
+                                    <span>Free Trial (14 days)</span>
+                                </label>
+                            </div>
+                            {errors.isTrial && <p className="text-red-500 text-sm">{errors.isTrial.message}</p>}
+                        </div>
+
+                        <ButtonPrimary type="submit" loading={isSubmitting || isLoading}>
+                            Continue to Checkout
+                        </ButtonPrimary>
+                    </>
+                )}
 
                 <p className="text-sm text-gray-700">
                     Already have an account?{" "}


### PR DESCRIPTION
## Summary
- refactor the admin signup form to use a `step` state
- first step collects the email and verifies it
- second step collects store details and, if needed, owner information
- remove blur-based email check and reset effects

## Testing
- `npx tsc --noEmit` *(fails: cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_6849c9878238832fbc06b54fa0f9c343